### PR TITLE
Add package.json + MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Anthony Pigeot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "smath",
+  "version": "1.0.0",
+  "description": "Optimized math functions",
+  "main": "src/SMath.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Malharhak/smath.js.git"
+  },
+  "author": "Anthony Pigeot <anthony.pigeot@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Malharhak/smath.js/issues"
+  },
+  "homepage": "https://github.com/Malharhak/smath.js#readme"
+}


### PR DESCRIPTION
I've added a `package.json` file to make this module a true NodeJS citizen, allowing `require('smath')` rather than `require('smath/src/SMath')`. I've also added an MIT license, please let me know if that's not OK and I'll change it.

Note that this package will still require an `npm publish` in order to allow installation via `npm install smath` directly. Otherwise users will still have to run `npm install Malharhak/smath.js`.

More PRs to come, including full automated testing!